### PR TITLE
Implement format option

### DIFF
--- a/bin/geekhours
+++ b/bin/geekhours
@@ -18,9 +18,46 @@ def initialize():
 
 # Handlers for course_subparser
 def list_course(args: str, db_path: str):
-    """ geekhours course list """
+    """ geekhours course list
+
+    Options:
+        --format, -f: Format records to comma separated CSV or JSON and
+                      write to a file.
+        --output, -o: Specify a file path to save records.
+    """
     cmd = Command(db_path)
-    cmd.show(args.course)
+    records = cmd.show(args.course)
+    column = cmd.show_column(args.course)
+    default_name = ['courses.csv', 'courses.json']
+
+    if args.format == 'csv':
+        if args.output:
+            try:
+                cmd.dump_to_csv(records, args.output, column)
+                print(args.output)
+            except FileExistsError as error:
+                print(error)
+        else:
+            try:
+                cmd.dump_to_csv(records, default_name[0], column)
+                print(default_name[0])
+            except FileExistsError as error:
+                print(error)
+    if args.format == 'json':
+        if args.output:
+            try:
+                cmd.dump_to_json(records, args.output)
+                print(args.output)
+            except FileExistsError as error:
+                print(error)
+        else:
+            try:
+                cmd.dump_to_json(records, default_name[1])
+                print(default_name[1])
+            except FileExistsError as error:
+                print(error)
+    if not args.format:
+        print(records)
 
 
 def add_course(args: List[str], db_path: str):
@@ -37,9 +74,47 @@ def remove_course(args: str, db_path: str):
 
 # Handlers for done_subparser
 def list_done(args: str, db_path: str):
-    """ geekhours done list """
+    """ geekhours done list
+
+    Options:
+        --format, -f: Format records to comma separated CSV or JSON and
+                      write to a file.
+        --output, -o: Specify a file path to save records.
+    """
     cmd = Command(db_path)
-    cmd.show(args.done)
+    records = cmd.show(args.done)
+    column = cmd.show_column(args.done)
+    default_name = ['records.csv', 'records.json']
+
+    if args.format == 'csv':
+        if args.output:
+            try:
+                cmd.dump_to_csv(records, args.output, column)
+                print(args.output)
+            except FileExistsError as error:
+                print(error)
+        else:
+            try:
+                cmd.dump_to_csv(records, default_name[0], column)
+                print(default_name[0])
+            except FileExistsError as error:
+                print(error)
+    if args.format == 'json':
+        if args.output:
+            try:
+                cmd.dump_to_json(records, args.output)
+                print(args.output)
+            except FileExistsError as error:
+                print(error)
+        else:
+            try:
+                cmd.dump_to_json(records, default_name[1])
+                print(default_name[1])
+            except FileExistsError as error:
+                print(error)
+
+    if not args.format:
+        print(records)
 
 
 def add_done(args: str, db_path: str):
@@ -94,6 +169,14 @@ def get_args(today: str):
     # course list
     list_parser = course_subparser.add_parser('list', help='List the courses.')
     list_parser.set_defaults(course='course', handler=list_course)
+    list_parser.add_argument(
+        '-f',
+        '--format',
+        choices=['csv', 'json'],
+        help="Format records to comma separated CSV or JSON and write them to a file.\
+              'records.csv' or 'records.json' will be created depending on the format type.\
+              Use '--output' or '-o' options to specify a file name.")
+    list_parser.add_argument('-o', '--output', help="Specify a file path to save.")
 
     # done commnad
     done_parser = subparsers.add_parser('done', help='Manipulate done.')
@@ -128,6 +211,14 @@ def get_args(today: str):
 
     # done list
     done_list_parser = done_subparser.add_parser('list', help='List done.')
+    done_list_parser.add_argument(
+        '-f',
+        '--format',
+        choices=['csv', 'json'],
+        help="Format records to comma separated CSV or JSON and write them to a file.\
+              'records.csv' or 'records.json' will be created depending on the format type.\
+              Use '--output' or '-o' options to specify a file name.")
+    done_list_parser.add_argument('-o', '--output', help="Specify a file path to save.")
     done_list_parser.set_defaults(done='donelist', handler=list_done)
 
     args = parser.parse_args()

--- a/geekhours.md
+++ b/geekhours.md
@@ -80,6 +80,35 @@ $ geekhours done list
 ]
 ```
 
+## Format records to comma separated CSV or JSON
+
+The '-f' and '--format' options can be used to write records to comma separated CSV or JSON.
+
+### `geekhours course list` command:
+
+`courses.csv` or `courses.json` will be created depending on the format type.
+
+```
+$ geekhours course list -f|--format csv|json
+```
+
+### `geekhours done list` command:
+
+`records.csv` or `records.json` will be created depending on the format type.
+
+```
+$ geekhours done list -f|--format csv|json
+```
+
+### Specify the file name
+
+File name can be specified by giving it to `-o` or `--output` options.
+
+```
+$ geekhours course list -f csv -o [FILE-PATH]
+$ geekhours done list --format json --output [FILE-PATH]
+```
+
 ## Delete a record of study time
 
 ```

--- a/geekhours/command.py
+++ b/geekhours/command.py
@@ -13,6 +13,11 @@ class Command:
         self.database = Database(db_name)
         self.database.create_table()
 
+    def show_column(self, arg: str):
+        """ Call database.get_column() """
+        column = self.database.get_column(arg)
+        return column
+
     def show(self, arg: str):
         """ Call database.show() """
         records = self.database.show(arg)

--- a/geekhours/command.py
+++ b/geekhours/command.py
@@ -3,6 +3,7 @@
 __all__ = ['Command']
 
 import csv
+import json
 from pathlib import Path
 from typing import List, Tuple
 from geekhours.database import Database
@@ -60,3 +61,18 @@ class Command:
             csv_writer = csv.writer(outcsv, delimiter=',')
             for record in records:
                 csv_writer.writerow(record)
+
+    @staticmethod
+    def dump_to_json(records: str, jsonfile: str):
+        """ dump outputs to JSON and write it to a file.
+
+        args:
+            records: Target data to write.
+            jsonfile: File path to save.
+        """
+        jsonfile = Path(jsonfile)
+
+        if jsonfile.exists():
+            raise FileExistsError('{} exists'.format(jsonfile))
+        with open(str(jsonfile), 'w') as outjson:
+            json.dump(records, outjson)

--- a/geekhours/command.py
+++ b/geekhours/command.py
@@ -16,7 +16,7 @@ class Command:
     def show(self, arg: str):
         """ Call database.show() """
         records = self.database.show(arg)
-        print(records)
+        return records
 
     def insert_course(self, arg: List[str]):
         """ Call database.insert_course() """

--- a/geekhours/command.py
+++ b/geekhours/command.py
@@ -2,7 +2,9 @@
 
 __all__ = ['Command']
 
-from typing import List
+import csv
+from pathlib import Path
+from typing import List, Tuple
 from geekhours.database import Database
 
 
@@ -38,3 +40,23 @@ class Command:
     def remove_donelist(self, date: str, course: str):
         """ Call database.remove_donelist() """
         self.database.remove_donelist(date, course)
+
+    @staticmethod
+    def dump_to_csv(records: str, csvfile: str, fields: Tuple):
+        """ dump outputs to comma separated CSV.
+
+        args:
+            records: Target data to dump.
+            csvfile: File path to save.
+            fields: Tuple object of a header row of the records.
+        """
+        csvfile = Path(csvfile)
+
+        if csvfile.exists():
+            raise FileExistsError('{} exists'.format(csvfile))
+        with open(str(csvfile), 'w', newline='') as outcsv:
+            writer = csv.DictWriter(outcsv, fieldnames=fields)
+            writer.writeheader()
+            csv_writer = csv.writer(outcsv, delimiter=',')
+            for record in records:
+                csv_writer.writerow(record)

--- a/geekhours/database.py
+++ b/geekhours/database.py
@@ -39,6 +39,19 @@ class Database:
             self.cur.execute(donelist)
             self.cur.execute(course)
 
+    def get_column(self, table: str):
+        """ Get column names """
+        self.con.row_factory = sqlite3.Row
+        cur = self.con.cursor()
+
+        if table == self.course:
+            course_columns = cur.execute('SELECT * FROM course').fetchone()
+            columns = course_columns.keys()
+        elif table == self.donelist:
+            donelist_columns = cur.execute('SELECT * FROM donelist').fetchone()
+            columns = donelist_columns.keys()
+        return columns
+
     def show(self, table: str):
         """  Show table """
         if table == self.course:

--- a/geekhours/test/test_command.py
+++ b/geekhours/test/test_command.py
@@ -129,3 +129,18 @@ class TestCommand(unittest.TestCase):
 
         # Insertion for tearDown()
         self._command.insert_donelist(self._date, self._course_name_python, self._duration)
+
+    def test_dump_to_csv(self):
+        """ Test dump_to_csv()
+
+        Assert:
+            * The method succeeds with no error and returns None.
+            * FileExistsError is raised if file already exists.
+        """
+        records = self._command.show('course')
+        csvfile = self._db_path + 'test.csv'
+        fields = self._command.show_column('course')
+        self.assertIsNone(self._command.dump_to_csv(records, csvfile, fields))
+
+        with self.assertRaises(FileExistsError):
+            self._command.dump_to_csv(records, csvfile, fields)

--- a/geekhours/test/test_command.py
+++ b/geekhours/test/test_command.py
@@ -51,6 +51,15 @@ class TestCommand(unittest.TestCase):
         self._command.remove_course(self._course_name_math)
         self._command.remove_course(self._course_name_eng)
 
+    def test_show_column(self):
+        """ Test show_column()
+
+        Assert show_colmun() calls Database.get_column() and
+        no exception is raised.
+        """
+        self._command.show_column('course')
+        self._command.show_column('donelist')
+
     def test_show(self):
         """ Test for show()
 

--- a/geekhours/test/test_command.py
+++ b/geekhours/test/test_command.py
@@ -54,10 +54,12 @@ class TestCommand(unittest.TestCase):
     def test_show(self):
         """ Test for show()
 
-        Assert show() calls the Database.show().
+        Assert;
+            * Command.show() calls the Database.show() and it succeeds.
+            * RuntimeError is raised if an invalid table name is passed.
         """
-        self.assertIsNone(self._command.show('course'))
-        self.assertIsNone(self._command.show('donelist'))
+        self._command.show('course')
+        self._command.show('donelist')
 
         wrong_name = None
         with self.assertRaises(RuntimeError):

--- a/geekhours/test/test_command.py
+++ b/geekhours/test/test_command.py
@@ -144,3 +144,17 @@ class TestCommand(unittest.TestCase):
 
         with self.assertRaises(FileExistsError):
             self._command.dump_to_csv(records, csvfile, fields)
+
+    def test_dump_to_json(self):
+        """ Test dump_to_json()
+
+        Assert:
+            * The method succeeds with no error and returns None.
+            * FileExistsError is raised if file already exists.
+        """
+        records = self._command.show('donelist')
+        jsonfile = self._db_path + 'test.json'
+        self.assertIsNone(self._command.dump_to_json(records, jsonfile))
+
+        with self.assertRaises(FileExistsError):
+            self._command.dump_to_json(records, jsonfile)

--- a/geekhours/test/test_database.py
+++ b/geekhours/test/test_database.py
@@ -95,6 +95,19 @@ class TestDatabase(unittest.TestCase):
         expected_course = tuple([expected_course])
         self.assertEqual(course.fetchone(), expected_course)
 
+    def test_get_column(self):
+        """ Test get_colmun()
+
+        Assert get_colmun() returns colmun names of the records.
+        """
+        course_columns = ['id', 'name']
+        donelist_columns = ['id', 'date', 'course', 'duration']
+
+        self.database.insert_course(self._courses)
+        self.assertEqual(self.database.get_column(self._course), course_columns)
+        self.database.insert_donelist(self._date, self._course_name, self._duration)
+        self.assertEqual(self.database.get_column(self._donelist), donelist_columns)
+
     def test_show(self):
         """ Test for show()
 


### PR DESCRIPTION
Add some options to format records and write it to a file.

`--format` and `-f` to format records which is output `geekhours course list` and `geekhours done lisrt` commands to CSV or JSON-formatted strings and write to a file.
`--output` and `-o` to specify a file path to save above data.

This PR closes #9.